### PR TITLE
test(nix): Update action to latest version

### DIFF
--- a/tests/action.yaml
+++ b/tests/action.yaml
@@ -31,7 +31,7 @@ runs:
         rebar3-version: '3'
 
     - if: ${{ steps.prepare.outputs.setup_nix == 'true' }}
-      uses: cachix/install-nix-action@v18
+      uses: cachix/install-nix-action@v22
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 


### PR DESCRIPTION
In order to fix the test on mason-registry, this bumps the Nix action to the latest version